### PR TITLE
Using shade id, instead of shade name to generate the accessory UUID

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ PowerViewPlatform.prototype.addShadeAccessory = function(shade) {
 	var name = Buffer.from(shade.name, 'base64').toString();
 	this.log("Adding shade %d: %s", shade.id, name);
 
-	var uuid = UUIDGen.generate(name);
+	var uuid = UUIDGen.generate(shade.id.toString());
 
 	var accessory = new Accessory(name, uuid);
 	accessory.context.shadeId = shade.id;


### PR DESCRIPTION
It's possible and completely reasonable for shades to use the same name in different rooms. The UUIDGen seems to generate the same UUID given the same input string. This means when multiple shades have the same name, we end up with UUID collisions and homebridge will generate an error. Instead, if we use the shade id (which is unique), we can generate a unique accessory UUID and prevent the error.